### PR TITLE
Correct web port for docker example

### DIFF
--- a/master/docs/tutorial/docker.rst
+++ b/master/docs/tutorial/docker.rst
@@ -64,12 +64,12 @@ Building and running Buildbot
   docker-compose up
 
 
-You should now be able to go to http://localhost:8010 and see a web page similar to:
+You should now be able to go to http://localhost:8080 and see a web page similar to:
 
 .. image:: _images/index.png
    :alt: index page
 
-Click on the `Waterfall Display link <http://localhost:8010/#/waterfall>`_ and you get this:
+Click on the `Waterfall Display link <http://localhost:8080/#/waterfall>`_ and you get this:
 
 .. image:: _images/waterfall-empty.png
    :alt: empty waterfall.


### PR DESCRIPTION
The docker example configuration in the tutorial uses port 8080 for the web interface, not 8010.